### PR TITLE
Small profile page aesthetics

### DIFF
--- a/components/BadgePreview.tsx
+++ b/components/BadgePreview.tsx
@@ -13,6 +13,7 @@ interface Props {
   description: string;
   totalCount: number;
   badgeCount?: number;
+  issuer: string;
 }
 
 export const BadgePreview: React.FC<Props> = ({
@@ -21,6 +22,7 @@ export const BadgePreview: React.FC<Props> = ({
   description,
   totalCount,
   badgeCount,
+  issuer,
 }) => {
   const isMobile = useMobile();
   const [showBadgeDetails, setShowBadgeDetails] = useState(false);
@@ -57,7 +59,7 @@ export const BadgePreview: React.FC<Props> = ({
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={imgSrc || '/default-avi.png'}
-          className="h-[100px] rounded-full"
+          className={'h-[100px] ' + (issuer === 'poap' ? 'rounded-full' : '')}
           alt={`${heading} badge`}
         />
         <div className="ml-6 flex flex-col gap-2">

--- a/pages/people/[address].tsx
+++ b/pages/people/[address].tsx
@@ -768,8 +768,6 @@ const Profile: React.FC<Props> = ({ address }) => {
                       const { badge_type, id } = badge;
                       const { image, description, title, issuer } = badge_type;
 
-                      console.log(title, issuer.name);
-
                       return (
                         <BadgePreview
                           key={id}

--- a/pages/people/[address].tsx
+++ b/pages/people/[address].tsx
@@ -289,7 +289,7 @@ const Profile: React.FC<Props> = ({ address }) => {
     <>
       <Toaster />
       <Head>
-        <title>{profile.username} | Mazury</title>
+        <title>{returnTruncatedIfEthAddress(profile.username)} | Mazury</title>
       </Head>
       <EditProfileModal
         isOpen={editProfileModalOpen}
@@ -321,7 +321,9 @@ const Profile: React.FC<Props> = ({ address }) => {
                 width={16}
                 height={16}
               />
-              <p className="font-demi">{profile.username}</p>
+              <p className="font-demi">
+                {returnTruncatedIfEthAddress(profile.username)}
+              </p>
 
               {/* Write referral button, large screens */}
               {!viewingOwnProfile && (
@@ -411,7 +413,9 @@ const Profile: React.FC<Props> = ({ address }) => {
                           }}
                           className={`no-scrollbar overflow-x-scroll font-demi text-indigoGray-90 md:overflow-auto`}
                         >
-                          {profile.username.length > 15 && isMobile
+                          {profile.username == profile.eth_address
+                            ? returnTruncatedIfEthAddress(profile.eth_address)
+                            : profile.username.length > 15 && isMobile
                             ? profile.username.slice(0, 10) + '...'
                             : profile.username}
                         </motion.h1>
@@ -558,16 +562,18 @@ const Profile: React.FC<Props> = ({ address }) => {
                       Badges
                     </div>
                   </div>
-                </div>
-                <div className="flex flex-col items-center gap-0">
-                  <motion.span
-                    style={{ fontSize: shouldCollapseHeader ? '24px' : '36px' }}
-                    className="font-serif font-bold"
-                  >
-                    {getMetricDisplayValue(posts.length)}
-                  </motion.span>
-                  <div className="text-xs uppercase text-indigoGray-60 opacity-60">
-                    Posts
+                  <div className="flex flex-col items-center gap-0">
+                    <motion.span
+                      style={{
+                        fontSize: shouldCollapseHeader ? '24px' : '36px',
+                      }}
+                      className="font-serif font-bold"
+                    >
+                      {getMetricDisplayValue(posts.length)}
+                    </motion.span>
+                    <div className="text-xs uppercase text-indigoGray-60 opacity-60">
+                      Posts
+                    </div>
                   </div>
                 </div>
               </div>

--- a/pages/people/[address].tsx
+++ b/pages/people/[address].tsx
@@ -766,7 +766,9 @@ const Profile: React.FC<Props> = ({ address }) => {
                     ?.slice(0, badgesExpanded ? badges.length : 4)
                     .map((badge) => {
                       const { badge_type, id } = badge;
-                      const { image, description, title } = badge_type;
+                      const { image, description, title, issuer } = badge_type;
+
+                      console.log(title, issuer.name);
 
                       return (
                         <BadgePreview
@@ -776,6 +778,7 @@ const Profile: React.FC<Props> = ({ address }) => {
                           imgSrc={image}
                           totalCount={totalBadgeCounts[badge_type.id]}
                           badgeCount={badgesCount}
+                          issuer={issuer.name}
                         />
                       );
                     })


### PR DESCRIPTION
- truncate if username is an eth address
- change the tab title
- align badge / referrals / posts count
- only poap badges are round